### PR TITLE
Fixed presentation documents not being disposed properly

### DIFF
--- a/PowerPoint_Adapter/AdapterActions/Push.cs
+++ b/PowerPoint_Adapter/AdapterActions/Push.cs
@@ -55,12 +55,38 @@ namespace BH.Adapter.PowerPoint
             if (pushType == PushType.AdapterDefault)
                 pushType = PushType.UpdateOnly;
 
-            // Open the presentation document
-            using (PresentationDocument presentationDoc = OpenTemplateDocument())
+
+            MemoryStream memoryStream = null;
+            PresentationDocument presentationDoc = null;
+            try
             {
-                if (presentationDoc == null)
-                    // The error message for a missing document is already covered by OpenTemplateDocument()
+                // Copy the content of the template into a MemoryStream
+
+                if (m_TemplateFileSettings != null)
+                    memoryStream = OpenTemplateFile(m_TemplateFileSettings.GetFullFileName());
+                else if (m_TemplateStream != null)
+                {
+                    memoryStream = new MemoryStream();
+                    m_TemplateStream.CopyTo(memoryStream);
+                }
+
+                if (memoryStream == null)
+                {
+                    BH.Engine.Base.Compute.RecordError("The content of the template was not extracted successfully.");
                     return new List<object>();
+                }
+
+                // Open the presentation
+
+                try
+                {
+                    presentationDoc = PresentationDocument.Open(memoryStream, true);
+                }
+                catch (Exception ex)
+                {
+                    BH.Engine.Base.Compute.RecordError(ex, "An error occurred while opening the presentation.");
+                    return new List<object>();
+                }
 
                 // Update the slides
                 PresentationPart presentationPart = presentationDoc.PresentationPart;
@@ -91,7 +117,7 @@ namespace BH.Adapter.PowerPoint
                 try
                 {
                     if (m_OutputFileSettings != null)
-                        presentationDoc.Clone(m_OutputFileSettings.GetFullFileName()).Dispose(); // Dispose the cloned document to avoid a memory leak
+                        presentationDoc.Clone(m_OutputFileSettings.GetFullFileName()).Dispose();
                     else if (m_OutputStream != null)
                     {
                         presentationDoc.Clone(m_OutputStream);
@@ -100,9 +126,14 @@ namespace BH.Adapter.PowerPoint
                 }
                 catch (Exception ex)
                 {
-                    BH.Engine.Base.Compute.RecordError(ex, "An error occurred while trying to save the changes");
-                    return new List<object>();
+                    BH.Engine.Base.Compute.RecordError(ex, "An error occurred when trying to save the presentation.");
                 }
+            }
+            finally
+            {
+                // Release all content from memory
+                presentationDoc?.Dispose();
+                memoryStream?.Close();
             }
 
             return objects.ToList();
@@ -112,35 +143,14 @@ namespace BH.Adapter.PowerPoint
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private PresentationDocument OpenTemplateDocument()
-        {
-            MemoryStream memoryStream = new MemoryStream();
-
-            if (m_TemplateFileSettings != null)
-                memoryStream = OpenTemplateFile(m_TemplateFileSettings.GetFullFileName());
-            else if (m_TemplateStream != null)
-                m_TemplateStream.CopyTo(memoryStream);
-            else
-            {
-                BH.Engine.Base.Compute.RecordError("Neither a template file settings nor a template file stream could be found to get the template file from.");
-                return null;
-            }
-
-            try
-            {
-                return PresentationDocument.Open(memoryStream, true);
-            }
-            catch (Exception ex)
-            {
-                BH.Engine.Base.Compute.RecordError(ex, "An error occurred while trying to open the template presentation.");
-                return null;
-            }
-        }
-
-        /***************************************************/
-
         private MemoryStream OpenTemplateFile(string filePath)
         {
+            if (!System.IO.File.Exists(filePath))
+            {
+                BH.Engine.Base.Compute.RecordError($"The template file: {filePath} does not exist.");
+                return null;
+            }
+
             // Copy the template file to the memory stream
             MemoryStream memoryStream = new MemoryStream();
             try
@@ -151,6 +161,7 @@ namespace BH.Adapter.PowerPoint
             catch (Exception ex)
             {
                 BH.Engine.Base.Compute.RecordError(ex, "An error occurred when trying to open the template file.");
+                memoryStream.Dispose();
                 return null;
             }
 

--- a/PowerPoint_Adapter/AdapterActions/Push.cs
+++ b/PowerPoint_Adapter/AdapterActions/Push.cs
@@ -55,40 +55,12 @@ namespace BH.Adapter.PowerPoint
             if (pushType == PushType.AdapterDefault)
                 pushType = PushType.UpdateOnly;
 
-
-            MemoryStream memoryStream = null;
-            PresentationDocument presentationDoc = null;
-            try
+            // Open the presentation document
+            using (PresentationDocument presentationDoc = OpenTemplateDocument())
             {
-
-                // Copy the content of the template into a MemoryStream
-
-                if (m_TemplateFileSettings != null)
-                    memoryStream = OpenTemplateFile(m_TemplateFileSettings.GetFullFileName());
-                else if (m_TemplateStream != null)
-                {
-                    memoryStream = new MemoryStream();
-                    m_TemplateStream.CopyTo(memoryStream);
-                }
-
-                if (memoryStream == null)
-                {
-                    BH.Engine.Base.Compute.RecordError("The content of the template was not extracted successfully.");
+                if (presentationDoc == null)
+                    // The error message for a missing document is already covered by OpenTemplateDocument()
                     return new List<object>();
-                }
-
-                // Open the presentation
-
-                try
-                {
-                    presentationDoc = PresentationDocument.Open(memoryStream, true);
-                }
-                catch (Exception e)
-                {
-                    memoryStream.Close();
-                    BH.Engine.Base.Compute.RecordError("Could not open the file: " + e.Message);
-                    return new List<object>();
-                }
 
                 // Update the slides
                 PresentationPart presentationPart = presentationDoc.PresentationPart;
@@ -119,33 +91,19 @@ namespace BH.Adapter.PowerPoint
                 try
                 {
                     if (m_OutputFileSettings != null)
-                        presentationDoc.Clone(m_OutputFileSettings.GetFullFileName());
+                        presentationDoc.Clone(m_OutputFileSettings.GetFullFileName()).Dispose(); // Dispose the cloned document to avoid a memory leak
                     else if (m_OutputStream != null)
                     {
                         presentationDoc.Clone(m_OutputStream);
                         m_OutputStream.Position = 0;
                     }
-
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    BH.Engine.Base.Compute.RecordError("Could not save the changes: " + e.Message);
-                }
-
-            }
-            finally
-            {
-                // Release all content from memory
-                if (presentationDoc != null)
-                {
-                    presentationDoc.Dispose();
-                }
-                if (memoryStream != null)
-                {
-                    memoryStream.Close();
+                    BH.Engine.Base.Compute.RecordError(ex, "An error occurred while trying to save the changes");
+                    return new List<object>();
                 }
             }
-
 
             return objects.ToList();
         }
@@ -154,31 +112,50 @@ namespace BH.Adapter.PowerPoint
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private MemoryStream OpenTemplateFile(string filePath)
+        private PresentationDocument OpenTemplateDocument()
         {
-            // Make sure the file exists
-            if (!File.Exists(filePath))
+            MemoryStream memoryStream = new MemoryStream();
+
+            if (m_TemplateFileSettings != null)
+                memoryStream = OpenTemplateFile(m_TemplateFileSettings.GetFullFileName());
+            else if (m_TemplateStream != null)
+                m_TemplateStream.CopyTo(memoryStream);
+            else
             {
-                BH.Engine.Base.Compute.RecordError($"There is no presentation with the file path {filePath}");
+                BH.Engine.Base.Compute.RecordError("Neither a template file settings nor a template file stream could be found to get the template file from.");
                 return null;
             }
 
+            try
+            {
+                return PresentationDocument.Open(memoryStream, true);
+            }
+            catch (Exception ex)
+            {
+                BH.Engine.Base.Compute.RecordError(ex, "An error occurred while trying to open the template presentation.");
+                return null;
+            }
+        }
+
+        /***************************************************/
+
+        private MemoryStream OpenTemplateFile(string filePath)
+        {
             // Copy the template file to the memory stream
             MemoryStream memoryStream = new MemoryStream();
             try
             {
-                FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                fileStream.CopyTo(memoryStream);
-                fileStream.Close();
+                using (FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    fileStream.CopyTo(memoryStream);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                BH.Engine.Base.Compute.RecordError("Could not open the file: " + e.Message);
+                BH.Engine.Base.Compute.RecordError(ex, "An error occurred when trying to open the template file.");
+                return null;
             }
 
             return memoryStream;
         }
-
 
         /***************************************************/
 
@@ -201,7 +178,3 @@ namespace BH.Adapter.PowerPoint
         /***************************************************/
     }
 }
-
-
-
-

--- a/PowerPoint_Adapter/AdapterActions/Push.cs
+++ b/PowerPoint_Adapter/AdapterActions/Push.cs
@@ -84,7 +84,7 @@ namespace BH.Adapter.PowerPoint
                 }
                 catch (Exception ex)
                 {
-                    BH.Engine.Base.Compute.RecordError(ex, "An error occurred while opening the presentation.");
+                    BH.Engine.Base.Compute.RecordError(ex, "An error occurred while opening the template presentation.");
                     return new List<object>();
                 }
 
@@ -145,7 +145,7 @@ namespace BH.Adapter.PowerPoint
 
         private MemoryStream OpenTemplateFile(string filePath)
         {
-            if (!System.IO.File.Exists(filePath))
+            if (!File.Exists(filePath))
             {
                 BH.Engine.Base.Compute.RecordError($"The template file: {filePath} does not exist.");
                 return null;
@@ -160,7 +160,7 @@ namespace BH.Adapter.PowerPoint
             }
             catch (Exception ex)
             {
-                BH.Engine.Base.Compute.RecordError(ex, "An error occurred when trying to open the template file.");
+                BH.Engine.Base.Compute.RecordError(ex, "An error occurred when trying to open the template presentation.");
                 memoryStream.Dispose();
                 return null;
             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3 

<!-- Add short description of what has been fixed -->
`PresentationDocument.Clone()` creates a clone of the document, which was not being disposed, and caused the document to be locked if a script was not closed. This has been fixed.
General handling of streams has been made more robust, with a `using` statement instead of a try/catch.

Disposal should only need to be done when saving to a file with output file settings: if the output file stream is disposed it would not be usable. 

### Test files
<!-- Link to test files to validate the proposed changes -->
[PowerPoint_Toolkit-#3.zip](https://github.com/user-attachments/files/16174025/PowerPoint_Toolkit-.3.zip)
Unzip and run the grasshopper script, with TemplateDocument.pptx file in the same directory. Then try to open the output file while the grasshopper file is still open.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
