### PR TITLE
Use paragraphs rather than new lines in MultiLineTextUpdate

### DIFF
--- a/PowerPoint_Adapter/CRUD/Update/Text.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Text.cs
@@ -119,19 +119,29 @@ namespace BH.Adapter.PowerPoint
             bool updateColour = !string.IsNullOrEmpty(update.Colour);
             List<Drawing.Paragraph> newParagraphs = new List<Drawing.Paragraph>();
 
+            Drawing.RunProperties lastRunProperties = null;
+            Drawing.ParagraphProperties lastParagraphProperties = null;
+
             for (int paragraphIndex = 0; paragraphIndex < update.Text.Count; paragraphIndex++)
             {
                 Drawing.Paragraph paragraph = (Drawing.Paragraph)paragraphs.ElementAtOrDefault(paragraphIndex)?.CloneNode(true) ?? new Drawing.Paragraph();
+
+                if (paragraph.ParagraphProperties == null && update.UseLastParagraphProperties)
+                    paragraph.AddChild(lastParagraphProperties ?? new Drawing.ParagraphProperties());
 
                 Drawing.Run run = (Drawing.Run)paragraph.GetFirstChild<Drawing.Run>()?.CloneNode(true) ?? paragraph.AppendChild(new Drawing.Run());
 
                 if (run.RunProperties != null)
                     run.RunProperties.SpellingError = null;
                 else
-                    run.RunProperties = new Drawing.RunProperties();
+                    // If using last run properties, use the last run properties (create new if null), otherwise create new run properties.
+                    run.AddChild(update.UseLastParagraphProperties ? lastRunProperties ?? new Drawing.RunProperties() : new Drawing.RunProperties());
 
                 if (updateColour)
                     SetFillColour(run.RunProperties, update.Colour);
+
+                lastRunProperties = (Drawing.RunProperties)run.RunProperties.CloneNode(true);
+                lastParagraphProperties = (Drawing.ParagraphProperties)paragraph.ParagraphProperties?.CloneNode(true);
 
                 paragraph.RemoveAllChildren<Drawing.Run>();
                 paragraph.AddChild(run);

--- a/PowerPoint_Adapter/CRUD/Update/Text.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Text.cs
@@ -109,53 +109,41 @@ namespace BH.Adapter.PowerPoint
                 return;
             }
 
-            // Replace the text
-            var paragraph = shape.Descendants<Drawing.Paragraph>().FirstOrDefault();
-            var runs = paragraph.Descendants<Drawing.Run>().ToList();
+            // Create text body and internal properties if they do not exist.
+            TextBody textBody = shape.TextBody ?? shape.AppendChild(new TextBody(new Drawing.BodyProperties(), new Drawing.ListStyle()));
 
-            int textCount = update.Text.Count;
-            int runCount = runs.Count;
+            List<Drawing.Paragraph> paragraphs = textBody.Elements<Drawing.Paragraph>().ToList();
 
-            string fullText = "";
-            for (int i = 0; i < update.Text.Count - 1; i++)
-            {
-                fullText += update.Text[i] + Environment.NewLine;
-            }
-            fullText += update.Text[update.Text.Count - 1];
+            //create a new paragraph in the text body with the text for that paragraph in a run if it does not already exist, otherwise change 
 
-            if (runs.Count == 0)
+            bool updateColour = !string.IsNullOrEmpty(update.Colour);
+            List<Drawing.Paragraph> newParagraphs = new List<Drawing.Paragraph>();
+
+            for (int paragraphIndex = 0; paragraphIndex < update.Text.Count; paragraphIndex++)
             {
-                paragraph.AddChild(new Drawing.Run(new Drawing.Text(fullText)));
-            }
-            else
-            {
-                Drawing.Text text = runs[0].Text;
-                if (text != null)
-                    text.Text = fullText;
+                Drawing.Paragraph paragraph = (Drawing.Paragraph)paragraphs.ElementAtOrDefault(paragraphIndex)?.CloneNode(true) ?? new Drawing.Paragraph();
+
+                Drawing.Run run = (Drawing.Run)paragraph.GetFirstChild<Drawing.Run>()?.CloneNode(true) ?? paragraph.AppendChild(new Drawing.Run());
+
+                if (run.RunProperties != null)
+                    run.RunProperties.SpellingError = null;
                 else
-                    runs.First().Text = new Drawing.Text(fullText);
+                    run.RunProperties = new Drawing.RunProperties();
 
-                Drawing.RunProperties runProps = runs[0].RunProperties;
-                if (runProps != null)
-                    runProps.SpellingError = null;  //Make sure no spelling error underlines are left from template
+                if (updateColour)
+                    SetFillColour(run.RunProperties, update.Colour);
+
+                paragraph.RemoveAllChildren<Drawing.Run>();
+                paragraph.AddChild(run);
+
+                Drawing.Text text = run.Text ?? run.AppendChild(new Drawing.Text());
+                text.Text = update.Text[paragraphIndex];
+
+                newParagraphs.Add(paragraph);
             }
 
-            for (int i = 1; i < runCount; i++)
-            {
-                runs[i].Remove();
-            }
-
-            if (!string.IsNullOrEmpty(update.Colour))
-            {
-                Drawing.RunProperties rp = shape.Descendants<Drawing.RunProperties>().FirstOrDefault();
-
-                if (rp == null)
-                {
-                    rp = new Drawing.RunProperties();
-                    shape.AddChild(rp);
-                }
-                SetFillColour(rp, update.Colour);
-            }
+            textBody.RemoveAllChildren<Drawing.Paragraph>();
+            textBody.Append(newParagraphs);
         }
 
         /***************************************************/

--- a/PowerPoint_oM/Update/MultiLineTextUpdate.cs
+++ b/PowerPoint_oM/Update/MultiLineTextUpdate.cs
@@ -42,6 +42,9 @@ namespace BH.oM.PowerPoint
 
         [Description("Colour of the text element that needs to be updated.")]
         public virtual string Colour { get; set; } = "";
+
+        [Description("Whether to use the properties of the previous paragraph for subsequent paragraphs where there is no text to update. If set to false, new paragraphs will have default properties with no indentation. Default false.")]
+        public virtual bool UseLastParagraphProperties { get; set; } = false;
     }
 }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #23 

<!-- Add short description of what has been fixed -->
Updated MultiLineTextUpdate to use separate paragraphs for new lines. When creating paragraphs after reaching the end of templated paragraphs, added a toggle that uses the last paragraph and run properties properties for any extra lines added.

### Test files
<!-- Link to test files to validate the proposed changes -->
[PowerPoint_Toolkit-23.zip](https://github.com/user-attachments/files/16691040/PowerPoint_Toolkit-23.zip)
Test running and toggling `UseLastParagraphProperites` on/off

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
