### PR TITLE
Added table update

### DIFF
--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.PowerPoint;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.PowerPoint;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;

--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -37,15 +37,9 @@ namespace BH.Adapter.PowerPoint
     {
         private void UpdateSlide(SlidePart slidePart, TableUpdate update)
         {
-            if (update.Contents.IsNullOrEmpty())
+            if (update.Contents == null || update.Contents.IsNullOrEmpty())
             {
                 BH.Engine.Base.Compute.RecordError("The table update has no contents to update the table with.");
-                return;
-            }
-
-            if (!update.Contents.All(x => update.Contents[0].Count == x.Count))
-            {
-                BH.Engine.Base.Compute.RecordError("The length of all of the rows in Content must be equal.");
                 return;
             }
 
@@ -57,6 +51,12 @@ namespace BH.Adapter.PowerPoint
 
             int rowCount = update.Contents.Count;
             int columnCount = update.Contents[0].Count;
+
+            if (!update.Contents.All(x => columnCount == x.Count))
+            {
+                BH.Engine.Base.Compute.RecordError("The length of all of the rows in Content must be equal.");
+                return;
+            }
 
             OpenXmlElement element = GetElementByName(slidePart, update.ElementName);
             GraphicFrame frame; //tables are contained within graphic frames
@@ -75,7 +75,7 @@ namespace BH.Adapter.PowerPoint
                     return;
             }
 
-            D.Table table = frame.Graphic?.GraphicData.GetFirstChild<D.Table>();
+            D.Table table = frame.Graphic?.GraphicData?.GetFirstChild<D.Table>();
 
             if (table == null)
             {
@@ -200,7 +200,6 @@ namespace BH.Adapter.PowerPoint
             D.BodyProperties bodyProperties = new D.BodyProperties();
             D.ListStyle listStyle = new D.ListStyle();
 
-            //TODO: figure out what to do about font size
             D.Paragraph par = new D.Paragraph();
             D.Run run = new D.Run();
             D.RunProperties runProps = new D.RunProperties();

--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -1,0 +1,177 @@
+﻿using BH.oM.PowerPoint;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using D = DocumentFormat.OpenXml.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using BH.Engine.Base;
+
+namespace BH.Adapter.PowerPoint
+{
+    public partial class PowerPointAdapter
+    {
+        private void UpdateSlide(SlidePart slidePart, TableUpdate update)
+        {
+            if (update.Contents.IsNullOrEmpty())
+            {
+                BH.Engine.Base.Compute.RecordError("The table update has no contents to update the table with.");
+                return;
+            }
+
+            if (!update.Contents.All(x => update.Contents[0].Count == x.Count))
+            {
+                BH.Engine.Base.Compute.RecordError("The length of all of the rows in Content must be equal.");
+                return;
+            }
+
+            if (update.Contents[0].IsNullOrEmpty())
+            {
+                BH.Engine.Base.Compute.RecordError("The table update has no contents to update the table with.");
+                return;
+            }
+
+            int rowCount = update.Contents.Count;
+            int columnCount = update.Contents[0].Count;
+
+            OpenXmlElement element = GetElementByName(slidePart, update.ElementName);
+            GraphicFrame frame; //tables are contained within graphic frames
+
+            switch (element) //if the element is a graphic frame already then just use that, but if it's a placeholder then there is nothing contained so need to create a new table from scratch
+            {
+                case GraphicFrame graphicFrame:
+                    frame = graphicFrame;
+                    break;
+                case Shape shape:
+                    frame = ConvertToGraphicFrame(shape, rowCount, columnCount);
+                    slidePart.Slide.CommonSlideData.ShapeTree.ReplaceChild(frame, shape);
+                    break;
+                default:
+                    BH.Engine.Base.Compute.RecordError($"The element with name '{update.ElementName}' on slide {update.SlideNumber} must be either a Shape, a Table, or a Table placeholder to be updated with a table.");
+                    return;
+            }
+
+            D.Table table = frame.Graphic?.GraphicData.GetFirstChild<D.Table>();
+
+            if (table == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"The element with the name `{update.ElementName}` on slide {update.SlideNumber} must contain a Table.");
+                return;
+            }
+
+            IEnumerable<D.GridColumn> columns = table.TableGrid.Descendants<D.GridColumn>();
+            IEnumerable<D.TableRow> rows = table.Descendants<D.TableRow>();
+
+            //compare to the column and row counts in the data to update.
+            if (columns.Count() != columnCount || rows.Count() != rowCount)
+            {
+                BH.Engine.Base.Compute.RecordError($"The shape of the data in Content must be the same shape as the table that is being updated.\nContent has {rowCount} rows and {columnCount} columns, whereas the table has {rows.Count()} rows and {columns.Count()} columns.");
+                return;
+            }
+
+            //update the text in each row/column - This assumes that each table cell will have only one paragraph and run originally and does not modify any other properties.
+
+            int r = 0;
+            int c = 0;
+            foreach (D.TableRow row in rows)
+            {
+                foreach (D.TableCell cell in row.Descendants<D.TableCell>())
+                {
+                    try
+                    {
+                        cell.TextBody.Elements<D.Paragraph>().Single().Elements<D.Run>().Single().Text.Text = update.Contents[r][c];
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        BH.Engine.Base.Compute.RecordWarning(ex, $"An error occurred while trying to update cell in row {r} column {c}, due to there being more than one paragraph or run in the template cell. This cell has not been updated, but others might have been. Occurred in element `{update.ElementName}` on slide {update.SlideNumber}.");
+                    }
+                    catch (Exception ex)
+                    {
+                        BH.Engine.Base.Compute.RecordWarning(ex, $"An error occurred while trying to update cell in row {r} column {c}. Occurred in element `{update.ElementName}` on slide {update.SlideNumber}.");
+                        return;
+                    }
+                    c++;
+                }
+                r++;
+                c = 0;
+            }
+        }
+
+        private static GraphicFrame ConvertToGraphicFrame(Shape oldShape, int rowCount, int columnCount)
+        {
+            ShapeProperties shapeProperties = (ShapeProperties)oldShape.Descendants<ShapeProperties>().Single().CloneNode(true);
+            NonVisualDrawingProperties drawingProps = (NonVisualDrawingProperties)oldShape.Descendants<NonVisualDrawingProperties>().Single().CloneNode(true);
+
+            return new GraphicFrame(
+                new NonVisualGraphicFrameProperties(
+                    drawingProps,
+                    new NonVisualGraphicFrameDrawingProperties(),
+                    new ApplicationNonVisualDrawingProperties()
+                    ),
+                new D.Graphic(
+                    new D.GraphicData(
+                        ConstructNewTable(rowCount, columnCount)
+                        ) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/table" }
+                    ),
+                shapeProperties
+                );
+        }
+
+        private static D.Table ConstructNewTable(int rowCount, int columnCount)
+        {
+            D.Table table = new D.Table();
+            D.TableProperties tableProperties = new D.TableProperties();
+            D.TableGrid tGrid = new D.TableGrid();
+
+            for (int i = 0; i < columnCount; i++)
+            {
+                tGrid.Append(new D.GridColumn());
+            }
+
+            table.Append(tableProperties);
+            table.Append(tGrid);
+
+            for (int row = 0; row < rowCount; row++)
+            {
+                D.TableRow tRow = new D.TableRow();
+                for (int col = 0; col < columnCount; col++)
+                {
+                    tRow.Append(ConstructNewTableCell());
+                }
+                table.Append(tRow);
+            }
+
+            return table;
+        }
+
+        private static D.TableCell ConstructNewTableCell()
+        {
+            D.TableCell cell = new D.TableCell();
+            D.TableCellProperties properties = new D.TableCellProperties();
+            D.TextBody textBody = new D.TextBody();
+            D.BodyProperties bodyProperties = new D.BodyProperties();
+            D.ListStyle listStyle = new D.ListStyle();
+
+            D.Paragraph par = new D.Paragraph();
+            D.Run run = new D.Run();
+            D.RunProperties runProps = new D.RunProperties();
+            D.Text text = new D.Text(); //.Text property is what will be modified later
+            run.Append(runProps);
+            run.Append(text);
+            D.EndParagraphRunProperties endProps = new D.EndParagraphRunProperties();
+
+            par.Append(run);
+            par.Append(endProps);
+            textBody.Append(bodyProperties);
+            textBody.Append(listStyle);
+            textBody.Append(par);
+
+            cell.Append(textBody);
+            cell.Append(properties);
+
+            return cell;
+        }
+    }
+}

--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -137,8 +137,11 @@ namespace BH.Adapter.PowerPoint
                             fontSize = update.UpdatedTextFontSize;
 
                         if (headerRow)
+                        {
                             run.Text.Text = update.HeaderRow[c];
-                        else 
+                            headerRow = false;
+                        }
+                        else
                             run.Text.Text = update.Contents[r][c];
 
                         run.RunProperties.FontSize = fontSize * 100;

--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -91,7 +91,7 @@ namespace BH.Adapter.PowerPoint
                     }
                     catch (Exception ex)
                     {
-                        BH.Engine.Base.Compute.RecordWarning(ex, $"An error occurred while trying to update cell in row {r} column {c}. Occurred in element `{update.ElementName}` on slide {update.SlideNumber}.");
+                        BH.Engine.Base.Compute.RecordError(ex, $"An error occurred while trying to update cell in row {r} column {c}. Occurred in element `{update.ElementName}` on slide {update.SlideNumber}.");
                         return;
                     }
                     c++;

--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -83,7 +83,7 @@ namespace BH.Adapter.PowerPoint
                     {
                         D.Run run = cell.TextBody.Elements<D.Paragraph>().Single().Elements<D.Run>().Single();
                         run.Text.Text = update.Contents[r][c];
-                        run.RunProperties.FontSize = update.UpdatedTextFontSize;
+                        run.RunProperties.FontSize = update.UpdatedTextFontSize * 100;
                     }
                     catch (InvalidOperationException ex)
                     {

--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -81,7 +81,9 @@ namespace BH.Adapter.PowerPoint
                 {
                     try
                     {
-                        cell.TextBody.Elements<D.Paragraph>().Single().Elements<D.Run>().Single().Text.Text = update.Contents[r][c];
+                        D.Run run = cell.TextBody.Elements<D.Paragraph>().Single().Elements<D.Run>().Single();
+                        run.Text.Text = update.Contents[r][c];
+                        run.RunProperties.FontSize = update.UpdatedTextFontSize;
                     }
                     catch (InvalidOperationException ex)
                     {
@@ -154,7 +156,7 @@ namespace BH.Adapter.PowerPoint
             return table;
         }
 
-        private static D.TableCell ConstructNewTableCell(int fontSize = 20)
+        private static D.TableCell ConstructNewTableCell()
         {
             D.TableCell cell = new D.TableCell();
             D.TableCellProperties properties = new D.TableCellProperties();
@@ -165,7 +167,7 @@ namespace BH.Adapter.PowerPoint
             //TODO: figure out what to do about font size
             D.Paragraph par = new D.Paragraph();
             D.Run run = new D.Run();
-            D.RunProperties runProps = new D.RunProperties() { FontSize = fontSize };
+            D.RunProperties runProps = new D.RunProperties();
             D.Text text = new D.Text(); //.Text property is what will be modified later
             run.Append(runProps);
             run.Append(text);

--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -52,11 +52,20 @@ namespace BH.Adapter.PowerPoint
             int rowCount = update.Contents.Count;
             int columnCount = update.Contents[0].Count;
 
-            if (!update.Contents.All(x => columnCount == x.Count))
+            if (update.Contents.Any(x => columnCount != x.Count))
             {
                 BH.Engine.Base.Compute.RecordError("The length of all of the rows in Content must be equal.");
                 return;
             }
+
+            if (update.HeaderRow.Count > 0 && update.HeaderRow.Count != columnCount)
+            {
+                BH.Engine.Base.Compute.RecordError($"The length of the header row ({update.HeaderRow.Count}) must be equal to the length of the content rows ({columnCount}).");
+                return;
+            }
+
+            if (update.HeaderRow.Count > 0)
+                rowCount += 1;
 
             OpenXmlElement element = GetElementByName(slidePart, update.ElementName);
             GraphicFrame frame; //tables are contained within graphic frames
@@ -97,6 +106,7 @@ namespace BH.Adapter.PowerPoint
 
             int r = 0;
             int c = 0;
+            bool headerRow = update.HeaderRow.Count != 0;
             foreach (D.TableRow row in rows)
             {
                 foreach (D.TableCell cell in row.Descendants<D.TableCell>())
@@ -112,14 +122,26 @@ namespace BH.Adapter.PowerPoint
                         }
 
                         D.Run run = par.Elements<D.Run>().SingleOrDefault();
+                        int? fontSize = null;
                         if (run == null)
                         {
                             run = new D.Run(new D.RunProperties(), new D.Text());
                             par.AddChild(run);
                         }
+                        else
+                            fontSize = run.RunProperties.FontSize / 100;
 
-                        run.Text.Text = update.Contents[r][c];
-                        run.RunProperties.FontSize = update.UpdatedTextFontSize * 100;
+                        if (update.UpdatedTextFontSize <= 0)
+                            fontSize = fontSize ?? 20;
+                        else
+                            fontSize = update.UpdatedTextFontSize;
+
+                        if (headerRow)
+                            run.Text.Text = update.HeaderRow[c];
+                        else 
+                            run.Text.Text = update.Contents[r][c];
+
+                        run.RunProperties.FontSize = fontSize * 100;
                     }
                     catch (InvalidOperationException ex)
                     {

--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -101,25 +101,33 @@ namespace BH.Adapter.PowerPoint
 
         private static GraphicFrame ConvertToGraphicFrame(Shape oldShape, int rowCount, int columnCount)
         {
-            ShapeProperties shapeProperties = (ShapeProperties)oldShape.Descendants<ShapeProperties>().Single().CloneNode(true);
+            ShapeProperties shapeProperties = (ShapeProperties)oldShape.Descendants<ShapeProperties>().Single();
             NonVisualDrawingProperties drawingProps = (NonVisualDrawingProperties)oldShape.Descendants<NonVisualDrawingProperties>().Single().CloneNode(true);
 
-            return new GraphicFrame(
+            GraphicFrame gf =  new GraphicFrame(
                 new NonVisualGraphicFrameProperties(
                     drawingProps,
                     new NonVisualGraphicFrameDrawingProperties(),
                     new ApplicationNonVisualDrawingProperties()
                     ),
-                new D.Graphic(
-                    new D.GraphicData(
-                        ConstructNewTable(rowCount, columnCount)
-                        ) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/table" }
-                    ),
-                shapeProperties
+                new Transform() { Offset = (D.Offset)shapeProperties.Transform2D.Offset.CloneNode(true), Extents = (D.Extents)shapeProperties.Transform2D.Extents.CloneNode(true) }
                 );
+
+            (long width, long height) = GetSizeOfShape(shapeProperties);
+
+            gf.Append(new D.Graphic(new D.GraphicData(ConstructNewTable(rowCount, columnCount, width, height)) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/table" }));
+
+            return gf;
         }
 
-        private static D.Table ConstructNewTable(int rowCount, int columnCount)
+        private static (long, long) GetSizeOfShape(ShapeProperties shapeProps)
+        {
+            long width = shapeProps.Transform2D.Extents.Cx;
+            long height = shapeProps.Transform2D.Extents.Cy;
+            return (width, height);
+        }
+
+        private static D.Table ConstructNewTable(int rowCount, int columnCount, long shapeWidth, long shapeHeight)
         {
             D.Table table = new D.Table();
             D.TableProperties tableProperties = new D.TableProperties();
@@ -127,7 +135,7 @@ namespace BH.Adapter.PowerPoint
 
             for (int i = 0; i < columnCount; i++)
             {
-                tGrid.Append(new D.GridColumn());
+                tGrid.Append(new D.GridColumn() { Width = shapeWidth / columnCount });
             }
 
             table.Append(tableProperties);
@@ -135,7 +143,7 @@ namespace BH.Adapter.PowerPoint
 
             for (int row = 0; row < rowCount; row++)
             {
-                D.TableRow tRow = new D.TableRow();
+                D.TableRow tRow = new D.TableRow() { Height = shapeHeight / rowCount };
                 for (int col = 0; col < columnCount; col++)
                 {
                     tRow.Append(ConstructNewTableCell());
@@ -146,7 +154,7 @@ namespace BH.Adapter.PowerPoint
             return table;
         }
 
-        private static D.TableCell ConstructNewTableCell()
+        private static D.TableCell ConstructNewTableCell(int fontSize = 20)
         {
             D.TableCell cell = new D.TableCell();
             D.TableCellProperties properties = new D.TableCellProperties();
@@ -154,9 +162,10 @@ namespace BH.Adapter.PowerPoint
             D.BodyProperties bodyProperties = new D.BodyProperties();
             D.ListStyle listStyle = new D.ListStyle();
 
+            //TODO: figure out what to do about font size
             D.Paragraph par = new D.Paragraph();
             D.Run run = new D.Run();
-            D.RunProperties runProps = new D.RunProperties();
+            D.RunProperties runProps = new D.RunProperties() { FontSize = fontSize };
             D.Text text = new D.Text(); //.Text property is what will be modified later
             run.Append(runProps);
             run.Append(text);

--- a/PowerPoint_Adapter/CRUD/Update/Table.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Table.cs
@@ -81,7 +81,21 @@ namespace BH.Adapter.PowerPoint
                 {
                     try
                     {
-                        D.Run run = cell.TextBody.Elements<D.Paragraph>().Single().Elements<D.Run>().Single();
+                        D.Paragraph par = cell.TextBody.Elements<D.Paragraph>().SingleOrDefault();
+                        if (par == null)
+                        {
+                            par = new D.Paragraph();
+                            par.AddChild(new D.Run(new D.RunProperties(), new D.Text()));
+                            cell.TextBody.AddChild(par);
+                        }
+
+                        D.Run run = par.Elements<D.Run>().SingleOrDefault();
+                        if (run == null)
+                        {
+                            run = new D.Run(new D.RunProperties(), new D.Text());
+                            par.AddChild(run);
+                        }
+
                         run.Text.Text = update.Contents[r][c];
                         run.RunProperties.FontSize = update.UpdatedTextFontSize * 100;
                     }

--- a/PowerPoint_oM/Update/TableUpdate.cs
+++ b/PowerPoint_oM/Update/TableUpdate.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/PowerPoint_oM/Update/TableUpdate.cs
+++ b/PowerPoint_oM/Update/TableUpdate.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/PowerPoint_oM/Update/TableUpdate.cs
+++ b/PowerPoint_oM/Update/TableUpdate.cs
@@ -16,5 +16,8 @@ namespace BH.oM.PowerPoint
 
         [Description("Content to be placed into the table. Outer list indexes correspond to row numbers, and inner list indexes correspond to the column numbers. each row must be the same length.")]
         public virtual List<List<string>> Contents { get; set; }
+
+        [Description("The font size of any text in the table.")]
+        public virtual int UpdatedTextFontSize { get; set; } = 20;
     }
 }

--- a/PowerPoint_oM/Update/TableUpdate.cs
+++ b/PowerPoint_oM/Update/TableUpdate.cs
@@ -34,10 +34,10 @@ namespace BH.oM.PowerPoint
         public virtual int SlideNumber { get; set; } = -1;
 
         [Description("Name of the table that needs to be updated.")]
-        public virtual string ElementName { get; set; }
+        public virtual string ElementName { get; set; } = "";
 
         [Description("Content to be placed into the table. Outer list indexes correspond to row numbers, and inner list indexes correspond to the column numbers. each row must be the same length.")]
-        public virtual List<List<string>> Contents { get; set; }
+        public virtual List<List<string>> Contents { get; set; } = new List<List<string>>();
 
         [Description("The font size of any text in the table.")]
         public virtual int UpdatedTextFontSize { get; set; } = 20;

--- a/PowerPoint_oM/Update/TableUpdate.cs
+++ b/PowerPoint_oM/Update/TableUpdate.cs
@@ -36,10 +36,13 @@ namespace BH.oM.PowerPoint
         [Description("Name of the table that needs to be updated.")]
         public virtual string ElementName { get; set; } = "";
 
+        [Description("Header row for the table. Leave empty to ignore and just make a table using the content. If not empty this list must be the same length as the rows in content.")]
+        public virtual List<string> HeaderRow { get; set; } = new List<string>();
+
         [Description("Content to be placed into the table. Outer list indexes correspond to row numbers, and inner list indexes correspond to the column numbers. each row must be the same length.")]
         public virtual List<List<string>> Contents { get; set; } = new List<List<string>>();
 
-        [Description("The font size of any text in the table.")]
-        public virtual int UpdatedTextFontSize { get; set; } = 20;
+        [Description("The font size of any text in the table. If set to 0, does not change the font size of elements in a previous table, or if the table is a placeholder, defaults to font size of 20.")]
+        public virtual int UpdatedTextFontSize { get; set; } = 0;
     }
 }

--- a/PowerPoint_oM/Update/TableUpdate.cs
+++ b/PowerPoint_oM/Update/TableUpdate.cs
@@ -1,0 +1,20 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.PowerPoint
+{
+    public class TableUpdate : BHoMObject, ISlideUpdate
+    {
+        [Description("Number of the slide where the update needs to happen.")]
+        public virtual int SlideNumber { get; set; } = -1;
+
+        [Description("Name of the table that needs to be updated.")]
+        public virtual string ElementName { get; set; }
+
+        [Description("Content to be placed into the table. Outer list indexes correspond to row numbers, and inner list indexes correspond to the column numbers. each row must be the same length.")]
+        public virtual List<List<string>> Contents { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #18 

<!-- Add short description of what has been fixed -->
Added ability to update text in a table within a slide. This also can apply to table placeholders (where the table isn't initially there but a placeholder shape is in its' place - in this case it converts the shape into the correct size table for the data being inserted).

### Test files
<!-- Link to test files to validate the proposed changes -->
unzip and make sure both files are in the same folder, then set run to true and compare the output.pptx file with template.pptx
[18-TableUpdate.zip](https://github.com/user-attachments/files/19647364/18-TableUpdate.zip)
The output slide should look like this:
![image](https://github.com/user-attachments/assets/c73357a3-a0a4-43fe-830b-97e7841e8c7a)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
 * Added ability to update tables within presentations with `TableUpdate`.

### Additional comments
<!-- As required -->
Other ideas: maybe a bool to allow forced update where an old table has the wrong number of rows/columns - if set to true this would change the number of rows/columns in the table to fit needs?