### PR TITLE
Consolidate versions of external dependencies

### DIFF
--- a/.ci/BHoMBot/Nuget/BHoM.Interop.PowerPoint.nuspec
+++ b/.ci/BHoMBot/Nuget/BHoM.Interop.PowerPoint.nuspec
@@ -18,7 +18,7 @@
       <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="2.0.3" />
         <dependency id="Microsoft.CSharp" version="4.7.0" />
-        <dependency id="DocumentFormat.OpenXml" version="2.19.0" />
+        <dependency id="DocumentFormat.OpenXml" version="3.1.1" />
       </group>
     </dependencies>
   </metadata>

--- a/PowerPoint_Adapter/CRUD/Update/Image.cs
+++ b/PowerPoint_Adapter/CRUD/Update/Image.cs
@@ -81,7 +81,7 @@ namespace BH.Adapter.PowerPoint
             }
 
             // Add the image to the PowerPoint
-            ImagePartType imageType = ImagePartType.Jpeg;
+            PartTypeInfo imageType = ImagePartType.Jpeg;
 
             switch (System.IO.Path.GetExtension(update.ImageFilePath).ToLower())
             {
@@ -164,7 +164,7 @@ namespace BH.Adapter.PowerPoint
             }
 
             // Add the image to the PowerPoint
-            ImagePartType imageType = ImagePartType.Jpeg;
+            PartTypeInfo imageType = ImagePartType.Jpeg;
             switch (update.ImageType.ToLower())
             {
                 case "bmp":

--- a/PowerPoint_Adapter/PowerPoint_Adapter.csproj
+++ b/PowerPoint_Adapter/PowerPoint_Adapter.csproj
@@ -24,9 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.1.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -93,7 +92,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)DocumentFormat.OpenXml.dll&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)System.IO.Packaging.dll&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
+    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)DocumentFormat.OpenXml.dll&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)DocumentFormat.OpenXml.Framework.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)System.IO.Packaging.dll&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
   </Target>
 
 </Project>


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #104

System.IO.Packaging 6.0.0 is vulnerable so we are now targeting version 8.0.1. This will be done indirectly by
- Upgrading DocumentFormat.OpenXml to 3.1.1
- Removing direct dependency to System.IO.Packaging

This is related to those PR and should be tested together:
- https://github.com/BHoM/SAP_Toolkit/pull/188
- https://github.com/BHoM/Excel_Toolkit/pull/105

### Test files
Usual testing procedure


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->